### PR TITLE
splice→slice; display all requirements correctly

### DIFF
--- a/src/adapt.js
+++ b/src/adapt.js
@@ -110,14 +110,15 @@ class RequirementSection extends React.Component {
       )
     });
     var half_length = Math.ceil(children.length / 2);
-    var leftSide = children.splice(0,half_length);
+    var leftSide = children.slice(0,half_length);
+    var rightSide = children.slice(half_length, children.length);
     return (
       <Grid columns='equal' stretched doubling verticalAlign='middle'>
         <Grid.Row verticalAlign='middle'>
         {leftSide}
         </Grid.Row>
         <Grid.Row>
-        {leftSide}
+        {rightSide}
         </Grid.Row>
       </Grid>
     );


### PR DESCRIPTION
As far as I can tell, all requirement categories should be displayed. Previously, all categories were displayed twice.

Also, `Array#splice` [apparently](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice) mutates an array, while `Array#slice` [returns a shallow copy](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice), more like an array slice in Python.