### PR TITLE
Run package install and dev build with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: node_js
+node_js:
+    - 7
+    - 6
+script:
+    - react-scripts build


### PR DESCRIPTION
We're only testing with Node v6 and v7 because Yarn has dropped support
for earlier versions of Node. I assume this is because v5 is no longer
supported (it wasn't an LTS release), and v4 has enetered "maintenance"
since v6 has taken over as the active stable version which will be
supported until April 2018 (at which point v8 will take over. LTS is
active for 18 mos.)[1][1]

[1]: https://github.com/nodejs/LTS